### PR TITLE
[PATCH] Let X-FORWARDED-FOR supersede REMOTE_ADDR.

### DIFF
--- a/action.php
+++ b/action.php
@@ -120,7 +120,7 @@ class action_plugin_logstats extends DokuWiki_Action_Plugin {
     public function logAccess($page, $status, $size, $referer = '') {
         global $conf;
 
-        $host      = $_SERVER['REMOTE_ADDR'];
+        $host      = isset($_SERVER['X-FORWARDED-FOR']) ? $_SERVER['X-FORWARDED-FOR'] : $_SERVER['REMOTE_ADDR'];
         $user      = isset($_SERVER['REMOTE_USER']) ? $_SERVER['REMOTE_USER'] : "-";
         $timestamp = date("[d/M/Y:H:i:s O]");
         $method    = isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : "";


### PR DESCRIPTION
Hi,

This patch makes logstats use the X-FORWARDED-FOR instead of REMOTE_ADDR in case X-FORWARDED-FOR is set in order for logstats to read the correct IP address in case dokuwiki is behind a reverse proxy.

There are cases where dokuwiki sits behind squid, varnish or even apache acting as a reverse proxy and in the current format, logstats is unable to get the real IP address. What is worse, is that if dokuwiki is behind a reverse proxy, logstats will only see one single address (the address of the upstream proxy) which will give out entirely wrong visitor counts.

By using this patch, logstats first checks whether the X-FORWARDED-FOR header exists, and if it does, then it uses that as the IP address. In case X-FORWARDED-FOR does not exist, then it uses the regular REMOTE_ADDR to grab the IP address.

Kind regards,
Eva
